### PR TITLE
Added daylight savings rounding rules for Asia/Tehran

### DIFF
--- a/include/tz_database.hrl
+++ b/include/tz_database.hrl
@@ -35,6 +35,7 @@
       %%   Discarded excess rules for Zone Africa/El_Aaiun.
       %%   Moving rule to beginning of day for Zone America/Godthab.
       %%   Moving rule to beginning of day for Zone America/Godthab.
+      %%   Rounded timezone rules of Asia/Tehran to week 3 in march and september
 
       {"Africa/Abidjan",{"GMT","GMT"},undef,0,0,undef,{0,0},undef,{0,0}},
       {"Africa/Accra",{"GMT","GMT"},undef,0,0,undef,{0,0},undef,{0,0}},
@@ -346,7 +347,7 @@
       {"Asia/Taipei",{"CST","CST"},undef,480,0,undef,{0,0},undef,{0,0}},
       {"Asia/Tashkent",{"UZT","UZT"},undef,300,0,undef,{0,0},undef,{0,0}},
       {"Asia/Tbilisi",{"GET","GET"},undef,240,0,undef,{0,0},undef,{0,0}},
-      {"Asia/Tehran",{"IRST","IRST"},{"IRDT","IRDT"},210,60,undef,{0,0},undef,{0,0}},
+      {"Asia/Tehran",{"IRST","IRST"},{"IRDT","IRDT"},210,60,{3,sat,mar},{0,0},{3,sat,sep},{0,0}},
       {"Asia/Tel_Aviv",{"IST","IST"},{"IDT","IDT"},120,60,{4,fri,mar},{2,0},{last,sun,oct},{2,0}},
       {"Asia/Thimbu",{"BTT","BTT"},undef,360,0,undef,{0,0},undef,{0,0}},
       {"Asia/Thimphu",{"BTT","BTT"},undef,360,0,undef,{0,0},undef,{0,0}},

--- a/src/localtime.erl
+++ b/src/localtime.erl
@@ -255,6 +255,12 @@ tr_char_test() ->
    ?assertEqual("AB_DE", tr_char("AB DE", ?SPACE_CHAR, $_)),
    ?assertEqual("A_C_E", tr_char("A C E", ?SPACE_CHAR, $_)).
 
+tz_name_test() ->
+    ?assertEqual({"CET", "CET"}, tz_name({{2008,12,10},{15,30,0}}, "Europe/Amsterdam")),
+    ?assertEqual({"IRST", "IRST"}, tz_name({{2008,12,10},{15,30,0}}, "Asia/Tehran")),
+    ?assertEqual({"IRDT", "IRDT"}, tz_name({{2020,5,4},{15,30,0}}, "Asia/Tehran")).
+
+
 get_timezone_test() ->
    ?assertEqual("America/Los_Angeles", get_timezone("America/Los Angeles")).
 


### PR DESCRIPTION
Iran has more complex rules than other countries for switching to daylight savings and back. I have created a simple rounding rule to prevent the crash in #2. 